### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-ecs-filter.gemspec
+++ b/fluent-plugin-ecs-filter.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.0.0'
 
-  gem.add_runtime_dependency 'fluentd', '>= 0.10.43'
+  gem.add_runtime_dependency 'fluentd', ['>= 0.14.0', "< 2"]
   gem.add_runtime_dependency 'lru_redux', '~> 1.1'
   gem.add_runtime_dependency 'docker-api', '~> 1.33', '>= 1.33.3'
   gem.add_runtime_dependency 'oj', '>= 2.18.5'

--- a/lib/fluent/plugin/filter_ecs_filter.rb
+++ b/lib/fluent/plugin/filter_ecs_filter.rb
@@ -15,6 +15,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require 'docker-api'
+require 'lru_redux'
+require 'oj'
+require 'time'
+require 'vine'
 require 'fluent/plugin/filter'
 
 module Fluent::Plugin
@@ -32,12 +37,6 @@ module Fluent::Plugin
     # Get the configuration for the plugin
     def configure(conf)
       super
-
-      require 'docker-api'
-      require 'lru_redux'
-      require 'oj'
-      require 'time'
-      require 'vine'
 
       @cache_ttl = :none if @cache_ttl < 0
 

--- a/lib/fluent/plugin/filter_ecs_filter.rb
+++ b/lib/fluent/plugin/filter_ecs_filter.rb
@@ -15,7 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-module Fluent
+require 'fluent/plugin/filter'
+
+module Fluent::Plugin
   # Parses ECS data from docker to make fluentd logs more
   # useful.
   class ECSFilter < Filter
@@ -45,7 +47,7 @@ module Fluent
     # Gets the log event stream and moifies it. This is where the plugin hooks
     # into the fluentd envent stream.
     def filter_stream(tag, es)
-      new_es = MultiEventStream.new
+      new_es = Fluent::MultiEventStream.new
       container_id_from_tag = nil
 
       if container_id_attr.nil?

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -30,6 +30,7 @@ end
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/driver/filter'
 require 'webmock/test_unit'
 WebMock.disable_net_connect!(:allow => "codeclimate.com")
 


### PR DESCRIPTION
I've tried to migrate to use v0.14 Filter Plugin API.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.